### PR TITLE
Update precommit and buildx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build and push image.
         if: ${{ matrix.codename !='' }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./
           file: ${{ matrix.os }}/Dockerfile
@@ -95,7 +95,7 @@ jobs:
 
       - name: Build and push image.
         if: ${{ matrix.codename =='' }}
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: ./
           file: ${{ matrix.os }}/Dockerfile

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
     -   id: black


### PR DESCRIPTION
 - .github/workflows/ci.yml: #25 Bumps [docker/build-push-action](https://github.com/docker/build-push-action) from 4 to 5.
   + [Release notes](https://github.com/docker/build-push-action/releases)
   + [Commits](docker/build-push-action@v4...v5)
 - .pre-commit-config.yaml: #24 updates:
   + [github.com/pre-commit/pre-commit-hooks: v4.4.0 → v4.5.0](pre-commit/pre-commit-hooks@v4.4.0...v4.5.0)
   + [github.com/psf/black: 23.7.0 → 23.9.1](psf/black@23.7.0...23.9.1)